### PR TITLE
Add versioning support for dependencies 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,17 +17,13 @@ RUN set -x \
     && echo "sdkman_insecure_ssl=false" >> $SDKMAN_DIR/etc/config
 
 RUN source $SDKMAN_DIR/bin/sdkman-init.sh \
-	&& sdk install java \
-	&& sdk install kotlin \
 	&& sdk install maven \
 	&& sdk install gradle
-
 
 COPY entrypoint.sh /
 COPY ktest.kts / 
 
-ENV PATH="${PATH}:/usr/local/sdkman/candidates/java/current/bin"
-ENV PATH="${PATH}:/usr/local/sdkman/candidates/kotlin/current/bin"
+ENV PATH="${PATH}:/usr/local/sdkman/candidates/maven/current/bin"
 ENV PATH="${PATH}:/usr/local/sdkman/candidates/gradle/current/bin"
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,6 @@ RUN source $SDKMAN_DIR/bin/sdkman-init.sh \
 	&& sdk install java \
 	&& sdk install kotlin \
 	&& sdk install maven \
-	&& sdk install kscript \
 	&& sdk install gradle
 
 
@@ -29,7 +28,6 @@ COPY ktest.kts /
 
 ENV PATH="${PATH}:/usr/local/sdkman/candidates/java/current/bin"
 ENV PATH="${PATH}:/usr/local/sdkman/candidates/kotlin/current/bin"
-ENV PATH="${PATH}:/usr/local/sdkman/candidates/kscript/current/bin"
 ENV PATH="${PATH}:/usr/local/sdkman/candidates/gradle/current/bin"
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -12,6 +12,12 @@ This action will run the unit tests in a [Kscript](https://github.com/holgerbran
 
 **Required** The path to the `*.kts` file under test in your Github Project. 
 
+### `kscript-version`
+
+**Required** The [kscript version](https://github.com/holgerbrandl/kscript/releases) to be used in the action. 
+
+Default value passed is `'3.0.2'`
+
 ## Example usage
 
 The kscript-action depends on the [actions/checkout](https://github.com/actions/checkout) as this will checkout out your project into a repository the script is looking for to run the tests from. 
@@ -36,4 +42,5 @@ jobs:
       uses: plusmobileapps/kscript-action@v1
       with:
         kts-file: 'star-wars-char-enum.kts'
+        kscript-version: '3.0.2'
 ```

--- a/README.md
+++ b/README.md
@@ -14,9 +14,21 @@ This action will run the unit tests in a [Kscript](https://github.com/holgerbran
 
 ### `kscript-version`
 
-**Required** The [kscript version](https://github.com/holgerbrandl/kscript/releases) to be used in the action. 
+The [kscript version](https://sdkman.io/sdks#kscript) to be used in the action. 
 
-Default value passed is `'3.0.2'`
+Default value: `'3.1.0'`
+
+### `java-version`
+
+The [JDK](https://sdkman.io/jdks) to be used in the action
+
+Default value: `'11.0.10.hs-adpt'`
+
+### `kotlin-version`
+
+The [Kotlin](https://sdkman.io/) version to be used in the action
+
+Default value: `'1.4.31'`
 
 ## Example usage
 
@@ -39,7 +51,7 @@ jobs:
       uses: actions/checkout@v2.3.4
     - name: Run testing script to generate mock IDEA project and run gradle test
       id: hello
-      uses: plusmobileapps/kscript-action@v1
+      uses: plusmobileapps/kscript-action@v1.1
       with:
         kts-file: 'star-wars-char-enum.kts'
         kscript-version: '3.0.2'

--- a/action.yml
+++ b/action.yml
@@ -4,8 +4,13 @@ inputs:
   kts-file:  # id of input
     description: 'the path to the kts file in your repository i.e. hello-world.kts if at the root of the project'
     required: true
+  kscript-version: 
+    description: the version of kscript to be used in the action 
+    required: true 
+    default: '3.0.2'
 runs:
   using: 'docker'
   image: 'Dockerfile'
   args:
     - ${{ inputs.kts-file }}
+    - ${{ inputs.kscript-version }}

--- a/action.yml
+++ b/action.yml
@@ -5,12 +5,22 @@ inputs:
     description: 'the path to the kts file in your repository i.e. hello-world.kts if at the root of the project'
     required: true
   kscript-version: 
-    description: the version of kscript to be used in the action 
+    description: version of kscript to be used in the action https://sdkman.io/sdks#kscript
     required: true 
-    default: '3.0.2'
+    default: '3.1.0'
+  java-version: 
+    description: version of java to be used in the action https://sdkman.io/jdks
+    required: true
+    default: '11.0.10.hs-adpt'
+  kotlin-version: 
+    description: version of kotlin to be used in the action https://sdkman.io/sdks#kotlin
+    required: true
+    default: '1.4.31'
 runs:
   using: 'docker'
   image: 'Dockerfile'
   args:
     - ${{ inputs.kts-file }}
     - ${{ inputs.kscript-version }}
+    - ${{ inputs.java-version }}
+    - ${{ inputs.kotlin-version }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,10 +1,17 @@
 #!/bin/bash
 
+KTS_FILE=$1
+KSCRIPT_VERSION=$2
+JAVA_VERSION=$3
+KOTLIN_VERSION=$4
+
 # add sdk to the bash environment
 source "$SDKMAN_DIR/bin/sdkman-init.sh"
 
-# install kscript with the provided version 
-sdk install kscript $2
+# install kscript & dependencies with the provided versions
+sdk install kscript $KTS_FILE
+sdk install java $JAVA_VERSION
+sdk install kotlin $KOTLIN_VERSION
 
 # run the tests with the helper script
 # the project should be checked out at /github/workspace/ with the checkout action https://github.com/actions/checkout

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,9 +1,12 @@
-#!/bin/sh -l
+#!/bin/bash
+
+# add sdk to the bash environment
+source "$SDKMAN_DIR/bin/sdkman-init.sh"
 
 # install kscript with the provided version 
 sdk install kscript $2
 
-# add kscript ot the path 
+# add kscript to the path 
 export PATH=$PATH:/usr/local/sdkman/candidates/kscript/current/bin
 
 # run the tests with the helper script

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -11,8 +11,8 @@ source "$SDKMAN_DIR/bin/sdkman-init.sh"
 # install kscript & dependencies with the provided versions
 sdk install java $JAVA_VERSION
 sdk install kotlin $KOTLIN_VERSION
-sdk install kscript $KTS_FILE
+sdk install kscript $KSCRIPT_VERSION
 
 # run the tests with the helper script
 # the project should be checked out at /github/workspace/ with the checkout action https://github.com/actions/checkout
-kscript /ktest.kts /github/workspace/$1
+kscript /ktest.kts /github/workspace/$KTS_FILE

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,10 +1,11 @@
 #!/bin/sh -l
 
-kscript /ktest.kts /github/workspace/$1
+# install kscript with the provided version 
+sdk install kscript $2
 
-# if [[ $? -eq 0 ]]; then
-#     echo "Tests passed. Do something."
-# else
-#     echo "Tests didn't pass. Do something."
-#     exit 1
-# fi
+# add kscript ot the path 
+export PATH=$PATH:/usr/local/sdkman/candidates/kscript/current/bin
+
+# run the tests with the helper script
+# the project should be checked out at /github/workspace/ with the checkout action https://github.com/actions/checkout
+kscript /ktest.kts /github/workspace/$1

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -9,9 +9,9 @@ KOTLIN_VERSION=$4
 source "$SDKMAN_DIR/bin/sdkman-init.sh"
 
 # install kscript & dependencies with the provided versions
-sdk install kscript $KTS_FILE
 sdk install java $JAVA_VERSION
 sdk install kotlin $KOTLIN_VERSION
+sdk install kscript $KTS_FILE
 
 # run the tests with the helper script
 # the project should be checked out at /github/workspace/ with the checkout action https://github.com/actions/checkout

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -6,9 +6,6 @@ source "$SDKMAN_DIR/bin/sdkman-init.sh"
 # install kscript with the provided version 
 sdk install kscript $2
 
-# add kscript to the path 
-export PATH=$PATH:/usr/local/sdkman/candidates/kscript/current/bin
-
 # run the tests with the helper script
 # the project should be checked out at /github/workspace/ with the checkout action https://github.com/actions/checkout
 kscript /ktest.kts /github/workspace/$1


### PR DESCRIPTION
# Overview 

Add variables to GitHub Action for kscript, java, and kotlin 

## Description 

Since GitHub Actions does not currently support passing build arguments from an action to the docker file building the container ([GitHub Action forum](https://github.community/t/feature-request-build-args-support-in-docker-container-actions/16846/11)), I moved the installation of kscript, gradle, and kotlin dependencies to the `entrypoint.sh` file where the action parameters can be used. 

## Issue

[Link](https://github.com/plusmobileapps/kscript-action/issues/1)